### PR TITLE
Fix detecting version of GitBash

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -303,7 +303,7 @@ class BashComplete(ShellComplete):
         import subprocess
 
         output = subprocess.run(
-            ["bash", "-c", "echo ${BASH_VERSION}"], stdout=subprocess.PIPE
+            ["bash", "-c", 'echo "${BASH_VERSION}"'], stdout=subprocess.PIPE
         )
         match = re.search(r"^(\d+)\.(\d+)\.\d+", output.stdout.decode())
 


### PR DESCRIPTION
Shell version detection did not work if `BASH_VERSION` included syntactically relevant symbols, e.g. parenthesis:

```shell
/bin/bash: -c: line 0: syntax error near unexpected token `('
/bin/bash: -c: line 0: `echo 5.0.17(1)-release'
```

- fixes #2521

### Notes:

1. Please advice on how to test this bug.
2. I did not run any hooks or tests because the change is really minimal and does not justify setting up the dev-environment locally, IMO.
3. Update to CHANGELOG is still to do

### Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
